### PR TITLE
Remove unnecessary dependsOn

### DIFF
--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -64,12 +64,6 @@ object Bintray {
 
 fun TaskContainerScope.createSourceJar(vararg includeProjectNames: String): Jar =
     create("sourceJar", Jar::class) {
-        val isAndroid = project.isAndroidProject
-        if (isAndroid) {
-            dependsOn("assemble")
-        } else {
-            dependsOn("classes")
-        }
         classifier = "sources"
         setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 


### PR DESCRIPTION
also can build if removed these dependencies for the sourceJar task.