### PR TITLE
Add android target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.1] - 2020-08-11
+
+### Changed
+- Add Android library target to support resolution of gradle module metadata.
+
 ## [0.3.0] - 2020-08-11
 
 ### Changed

--- a/buildSrc/src/main/kotlin/PluginManagement.kt
+++ b/buildSrc/src/main/kotlin/PluginManagement.kt
@@ -9,8 +9,6 @@ object PluginsId {
     const val nodeGradle = "com.moowork.node"
 
     // Android
-    const val androidApplication = "com.android.application"
-    const val androidLibrary = "com.android.library"
     const val androidJunit5 = "de.mannodermaus.android-junit5"
 
     // Android Kotlin
@@ -23,11 +21,15 @@ object PluginsId {
 fun ScriptHandlerScope.legacyBuildScriptClasspath() {
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
+        classpath("com.android.tools.build:gradle:${Versions.androidGradlePlugin}")
     }
 }
 
 val PluginDependenciesSpec.kotlinMultiPlatform
     get() = id("org.jetbrains.kotlin.multiplatform") // version Versions.kotlin // for legacy
+
+val PluginDependenciesSpec.androidLibrary
+    get() = id("com.android.library")
 
 // endregion
 

--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -2,7 +2,7 @@ import org.gradle.api.Project
 
 private const val majorVersion: Int = 0
 private const val minorVersion: Int = 3
-private val patchVersion = 0
+private val patchVersion = 1
 private const val coreModuleName = "core"
 
 val Project.publishingGroupId: String

--- a/subprojects/core/core.build.gradle.kts
+++ b/subprojects/core/core.build.gradle.kts
@@ -3,13 +3,43 @@ import com.jfrog.bintray.gradle.BintrayExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    androidLibrary
     kotlinMultiPlatform
     bintray
     `maven-publish`
 }
 
+android {
+    compileSdkVersion(AndroidSdk.compileSdkVersion)
+
+    defaultConfig {
+        minSdkVersion(AndroidSdk.minSdkVersion)
+        targetSdkVersion(AndroidSdk.targetSdkVersion)
+        versionName = publishingArtifactVersion
+        consumerProguardFiles("proguard-rules.pro")
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+
+    sourceSets {
+        val main by getting {
+            manifest.srcFile("src/androidMain/AndroidManifest.xml")
+            java.srcDirs("src/androidMain/kotlin")
+        }
+        val test by getting {
+            java.srcDirs("src/androidTest/kotlin")
+        }
+    }
+}
+
 kotlin {
     jvm()
+    android {
+        publishLibraryVariants("release")
+    }
 
     sourceSets {
         val commonMain by getting {
@@ -44,6 +74,24 @@ kotlin {
                 implementation(TestLibs.assertkJvm)
             }
         }
+
+        val androidMain by getting {
+            dependencies {
+                implementation(Libs.kotlinStdlibJvm)
+                implementation(Libs.coroutinesCoreJvm)
+            }
+        }
+
+        val androidTest by getting {
+            dependencies {
+                runtimeOnly(TestLibs.junit5Engine)
+                implementation(TestLibs.kotlinTestJunit5)
+                implementation(TestLibs.kotlinReflectJvm)
+                implementation(TestLibs.junit5)
+                implementation(TestLibs.junit5Param)
+                implementation(TestLibs.assertkJvm)
+            }
+        }
     }
 }
 
@@ -61,7 +109,7 @@ tasks {
         }
     }
     // alias to allTests task (Kotlin MPP does not have test task)
-    register("test") { dependsOn("allTests") }
+    // register("test") { dependsOn("allTests") }
 }
 
 setProperty("archivesBaseName", publishingArtifactIdBase)

--- a/subprojects/core/src/androidMain/AndroidManifest.xml
+++ b/subprojects/core/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="co.uzzu.kortex"
+        >
+</manifest>


### PR DESCRIPTION
Since gradle 6.1.x or later, the gradle won't resolve jvm build target as Android target.

I'll add android library build target.